### PR TITLE
Removed constant frame_prefix value in TFStaticRelay

### DIFF
--- a/tf_relay/tf_static_relay.py
+++ b/tf_relay/tf_static_relay.py
@@ -22,7 +22,6 @@ class TFStaticRelay(Node):
             msg_type=TFMessage,
             topic='/tf_static',
             qos_profile=QoSProfile(reliability=QoSReliabilityPolicy.RELIABLE, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL , depth=10))
-        self.frame_prefix = 'agent_1/'
 
     def static_tf_callback(self, msg):
         for transform in msg.transforms:


### PR DESCRIPTION
I removed line 25 from tf_static_relay.py because I think this constant value had been mistakenly left in the commit.